### PR TITLE
[MinorVersion] Added chat profanity filter

### DIFF
--- a/game_resources/js/plugins/Online_Chat.js
+++ b/game_resources/js/plugins/Online_Chat.js
@@ -5,13 +5,13 @@ Imported.Online_Chat = true;
 var Nasty = Nasty || {};
 //=============================================================================
 // Online Chat
-// Version: 1.0.2
+// Version: 1.0.3
 //=============================================================================
 
 //=============================================================================
  /*:
  * @plugindesc Online Chat for Neldersons Online Core
- *<Online_Chat>
+ * <Online_Chat>
  * @author Nelderson
  *
  * @param Chat Key Code
@@ -33,9 +33,6 @@ var Nasty = Nasty || {};
  * @param Chat Text Color
  * @desc Color of chat text in chat window
  * @default #000000
- *
- * @param ===Chat Text Window===
- * @desc
  *
  * @param Chat Text Window Width
  * @desc Chat Window width
@@ -69,9 +66,6 @@ var Nasty = Nasty || {};
  * @desc Background Pic from img/pictures folder instead of Background Color
  * @default
  *
- * @param ===Chat Input Window===
- * @desc
- *
  * @param Chat Input Window Width
  * @desc Chat Input Window width
  * @default 600
@@ -103,6 +97,10 @@ var Nasty = Nasty || {};
  * @param Input Text Background Picture
  * @desc Background Pic from img/pictures folder instead of Background Color
  * @default
+ *
+ * @param Profanity Filter
+ * @desc Replace blacklisted words with asterixes
+ * @default true
  *
  * @help
  * ============================================================================
@@ -155,6 +153,8 @@ var Nasty = Nasty || {};
   var chatUserColor = Nasty.Parameters['Chat Username Color'];
   var chatTextColor = Nasty.Parameters['Chat Text Color'];
   var roomMapNameFlag = Nasty.Parameters['Room Name by Map'];
+
+  var profanityFilter = Nasty.Parameters['Profanity Filter'];
 
 var OnlineMV_ChatSystem_SocketConn_Alias = Game_Network.prototype.connectSocketsAfterLogin;
 Game_Network.prototype.connectSocketsAfterLogin = function(){
@@ -290,9 +290,10 @@ Game_Network.prototype.connectSocketsAfterLogin = function(){
      value = value.trim();
      if (value==='') return;
      //Emit message to server
-     socket.emit('clientMessage',{
-       message: value
-     });
+       socket.emit('clientMessage',{
+         message: value,
+         profanity: profanityFilter
+       });
      document.getElementById('chatInput').value = '';
    };
 

--- a/game_resources/js/plugins/Online_Chat.js
+++ b/game_resources/js/plugins/Online_Chat.js
@@ -98,10 +98,6 @@ var Nasty = Nasty || {};
  * @desc Background Pic from img/pictures folder instead of Background Color
  * @default
  *
- * @param Profanity Filter
- * @desc Replace blacklisted words with asterixes
- * @default true
- *
  * @help
  * ============================================================================
  * Introduction and Instructions
@@ -153,8 +149,6 @@ var Nasty = Nasty || {};
   var chatUserColor = Nasty.Parameters['Chat Username Color'];
   var chatTextColor = Nasty.Parameters['Chat Text Color'];
   var roomMapNameFlag = Nasty.Parameters['Room Name by Map'];
-
-  var profanityFilter = Nasty.Parameters['Profanity Filter'];
 
 var OnlineMV_ChatSystem_SocketConn_Alias = Game_Network.prototype.connectSocketsAfterLogin;
 Game_Network.prototype.connectSocketsAfterLogin = function(){
@@ -291,8 +285,7 @@ Game_Network.prototype.connectSocketsAfterLogin = function(){
      if (value==='') return;
      //Emit message to server
        socket.emit('clientMessage',{
-         message: value,
-         profanity: profanityFilter
+         message: value
        });
      document.getElementById('chatInput').value = '';
    };

--- a/server/configurations/chat.js
+++ b/server/configurations/chat.js
@@ -3,4 +3,5 @@ var Config = module.exports = {
 	//Main Configurations
 	//---------------------
 	enableLogging: true,
+	profanityFilter: false
 };

--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,8 @@
     "nodemailer": "^4.0.1",
     "passport-local-mongoose": "^4.0.0",
     "socket.io": "^1.7.3",
-    "socketio-jwt": "^4.5.0"
+    "socketio-jwt": "^4.5.0",
+    "swearjar": "^0.2.0"
   },
   "author": "Nelderson",
   "license": "MIT"

--- a/server/socket_modules/chat.js
+++ b/server/socket_modules/chat.js
@@ -1,4 +1,6 @@
 var config = require('./../configurations/chat');
+var swearjar = require('swearjar');
+
 module.exports = function (sio) {
 	var io = sio.of('/chat');
 
@@ -9,10 +11,15 @@ module.exports = function (sio) {
 
 		socket.on('clientMessage',function(data) {
 			data.id = username;
+			if (data.profanity){
+				data.message = swearjar.censor(data.message);
+			}
+
 			io.emit('messageServer',data);
-			
-			if (config.enableLogging)
+
+			if (config.enableLogging){
 				console.log(username + ': ' + data.message);
+			}			
 		});
 	});
 };

--- a/server/socket_modules/chat.js
+++ b/server/socket_modules/chat.js
@@ -11,7 +11,7 @@ module.exports = function (sio) {
 
 		socket.on('clientMessage',function(data) {
 			data.id = username;
-			if (data.profanity){
+			if (config.profanityFilter){
 				data.message = swearjar.censor(data.message);
 			}
 
@@ -19,7 +19,7 @@ module.exports = function (sio) {
 
 			if (config.enableLogging){
 				console.log(username + ': ' + data.message);
-			}			
+			}
 		});
 	});
 };


### PR DESCRIPTION
Added functionality to have certain words filtered in the chat window if the developer has profanity filter set to true. Using the lightweight swearjar (https://www.npmjs.com/package/swearjar) package. 

Also removed empty descriptor parameters from chat as they serve no purpose other than to bloat the file size, fields are descriptive enough without these header breaks in params.